### PR TITLE
Update README.md to fix a typo in MySQL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module.exports = {
 to
 
 ```
-module.exports: {
+module.exports = {
   client: 'mysql',
   connection: {
     host : '127.0.0.1',


### PR DESCRIPTION
I think `module.exports: {` should be `module.exports = {` otherwise there will be a SyntaxError.