### PR TITLE
default topic should not be deleted

### DIFF
--- a/api/admin.js
+++ b/api/admin.js
@@ -122,16 +122,28 @@ module.exports = function(app) {
       Topics.forge({id: req.body.id})
       .destroy()
       .then(function() {
-        res.json({
-          error: {
-            error: false,
-            message: ''
-          },
-          code: 'B127',
-          data: {
-
-          }
-        });
+        Articles.forge().where({topic_id: req.body.id})
+        .save({topic_id: 1}, {patch: true})
+        .then(() => {
+          res.json({
+            error: {
+              error: false,
+              message: ''
+            },
+            code: 'B127',
+            data: {}
+          });
+        })
+        .catch((error) => {
+          res.status(500).json({
+            error: {
+              error: true,
+              message: error.message
+            },
+            code: '',
+            data: {}
+          });
+        })
       })
       .catch(function (error) {
         res.status(500).json({

--- a/api/admin.js
+++ b/api/admin.js
@@ -108,9 +108,19 @@ module.exports = function(app) {
     It takes the id of the topic and then delete that record from the database.
     the error key in the returning object is a boolen which is false if there is no error and true otherwise
     */
-
-    Topics.forge({id: req.body.id})
-    .destroy()
+    if(+req.body.id === 1) {
+      res.status(403).json({
+        error: {
+          error: true,
+          message: 'Can not delete default topic!'
+        },
+        code: '',
+        data: {}
+      })
+    }
+    else {
+      Topics.forge({id: req.body.id})
+      .destroy()
       .then(function() {
         res.json({
           error: {
@@ -135,6 +145,7 @@ module.exports = function(app) {
           }
         });
       });
+    }
   });
 
 

--- a/client/app/components/admin.jsx
+++ b/client/app/components/admin.jsx
@@ -188,10 +188,10 @@ class Admin extends React.Component {
               <div className="list-group bordered-scroll-box">
                   {this.state.topics.map(topic => (
                     <div key={topic.id} href="#" className="list-group-item">
-                      <span className="pull-right">
-                        <Link to={'topic/edit/'+topic.id} className="btn btn-default">Edit</Link>
-                        <button className="btn btn-default" type="button" onClick={(e) => this.deleteTopic(topic.id,e)}>Delete</button>
-                      </span>
+                      {(topic.id !== 1)? <span className="pull-right">
+                      <Link to={'topic/edit/'+topic.id} className="btn btn-default">Edit</Link>
+                      <button className="btn btn-default" type="button" onClick={(e) => this.deleteTopic(topic.id,e)}>Delete</button>
+                      </span>: ''}
                       <h4 className="list-group-item-heading">{topic.name}</h4>
                       <p className="list-group-item-text">{topic.description}</p>
                     </div>


### PR DESCRIPTION
We should have a default topic that can't be deleted. This helps when deleting topics. All articles under the deleted topic can then be moved to the default topic.

The behavior of deleting topic is not defined yet. I suggest to move all the articles to the default topic.