### PR TITLE
Fixing the use of "&" on article titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ You can add `-v /<path>/db:/server/db` to store the db on the host filesystem, a
 to specify your own JWT secret configuration. Add `--restart=always -d` options to run it as a daemon.
 
 
+## Demo
+You can check a live demo of Matterwiki here: https://matterwiki.herokuapp.com
+
+
 ## Under the hood
 
 Matterwiki uses a Node.js API with a React.js front-end and Sqlite3 for the database.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ You can add `-v /<path>/db:/server/db` to store the db on the host filesystem, a
 to specify your own JWT secret configuration. Add `--restart=always -d` options to run it as a daemon.
 
 
-## Demo
-You can check a live demo of Matterwiki here: https://matterwiki.herokuapp.com
-
-
 ## Under the hood
 
 Matterwiki uses a Node.js API with a React.js front-end and Sqlite3 for the database.

--- a/client/app/components/edit.jsx
+++ b/client/app/components/edit.jsx
@@ -28,7 +28,7 @@ class EditArticle extends React.Component {
           });
           var myInit = { method: 'PUT',
                      headers: myHeaders,
-                     body: "id="+this.props.params.articleId+"&title="+title+"&body="+encodeURIComponent(body)+"&topic_id="+topicId+"&user_id="+window.localStorage.getItem("userId")+"&what_changed="+what_changed
+                     body: "id="+this.props.params.articleId+"&title="+encodeURIComponent(title)+"&body="+encodeURIComponent(body)+"&topic_id="+topicId+"&user_id="+window.localStorage.getItem("userId")+"&what_changed="+what_changed
                      };
           var that = this;
           fetch('/api/articles/',myInit)

--- a/client/app/components/new.jsx
+++ b/client/app/components/new.jsx
@@ -50,7 +50,7 @@ class NewArticle extends React.Component {
         });
         var myInit = { method: 'POST',
                    headers: myHeaders,
-                   body: "title="+title+"&body="+encodeURIComponent(body)+"&topic_id="+topicId+"&user_id="+window.localStorage.getItem("userId")
+                   body: "title="+encodeURIComponent(title)+"&body="+encodeURIComponent(body)+"&topic_id="+topicId+"&user_id="+window.localStorage.getItem("userId")
                    };
         var that = this;
         fetch('/api/articles/',myInit)


### PR DESCRIPTION
Just like the issue https://github.com/Matterwiki/Matterwiki/issues/25 , when you use the "&" on article titles it breaks.

Before:
![err1](https://cloud.githubusercontent.com/assets/7091570/22201834/899aae30-e14c-11e6-830c-72c9f0309e96.gif)

After the fix:
![err2](https://cloud.githubusercontent.com/assets/7091570/22201841/8ff9eaa2-e14c-11e6-9646-a2e59f22cdc3.gif)