### PR TITLE
URI-Encode email and password on login

### DIFF
--- a/client/app/components/login.jsx
+++ b/client/app/components/login.jsx
@@ -23,7 +23,7 @@ class Login extends React.Component {
     });
     var myInit = { method: 'POST',
                headers: myHeaders,
-               body: "email="+email+"&password="+password
+               body: "email="+encodeURIComponent(email)+"&password="+encodeURIComponent(password)
               };
     var that = this;
     fetch('/api/authenticate',myInit)


### PR DESCRIPTION
When creating a new user, the data (email, password, ...) is already URI-Encoded.
I think in login it was just forgotten.

This will fix Issue https://github.com/Matterwiki/Matterwiki/issues/84.
